### PR TITLE
FIX: always produce a main class or fail early when not possible.

### DIFF
--- a/src/main/scala/de/gccc/jib/JibPlugin.scala
+++ b/src/main/scala/de/gccc/jib/JibPlugin.scala
@@ -88,6 +88,7 @@ object JibPlugin extends AutoPlugin {
         sLog.value,
         Private.sbtLayerConfiguration.value,
         (mainClass in (Compile, packageBin)).value,
+        (discoveredMainClasses in (Compile, packageBin)).value,
         target.value / "jib" / "internal",
         credentials.value,
         baseImage,


### PR DESCRIPTION
JIB doesn't allow a `null` main class when producing the entrypoint. When there are more than one main classes in a project and `mainClass` isn't manually specified, this leads to a `NullpointerException`.

This change will check that sb-jib never passes a null main class into JIB by failing early if no main class can be used. It will also warn the user when it picks a class from multiple available ones.