### PR TITLE
Added useCurrentTimestamp flag

### DIFF
--- a/src/main/scala/de/gccc/jib/JibPlugin.scala
+++ b/src/main/scala/de/gccc/jib/JibPlugin.scala
@@ -36,6 +36,7 @@ object JibPlugin extends AutoPlugin {
     val jibEnvironment                 = settingKey[Map[String, String]]("jib docker env variables")
     val jibMappings                    = taskKey[Seq[(File, String)]]("jib additional resource mappings")
     val jibExtraMappings               = taskKey[Seq[(File, String)]]("jib extra file mappings / i.e. java agents")
+    val jibUseCurrentTimestamp         = settingKey[Boolean]("jib use current timestamp for image creation time. Default to Epoch")
 
     private[jib] object Private {
       val sbtLayerConfiguration = taskKey[List[LayerConfiguration]]("jib layer configuration")
@@ -62,6 +63,7 @@ object JibPlugin extends AutoPlugin {
     mappings in JibExtra := Nil,
     jibMappings := (mappings in Jib).value,
     jibExtraMappings := (mappings in JibExtra).value,
+    jibUseCurrentTimestamp := false,
     // private values
     Private.sbtLayerConfiguration := {
       val stageDirectory     = target.value / "jib" / "stage"
@@ -106,7 +108,8 @@ object JibPlugin extends AutoPlugin {
       jibBaseImage.value,
       jibJvmFlags.value,
       jibArgs.value,
-      jibEnvironment.value
+      jibEnvironment.value,
+      jibUseCurrentTimestamp.value
     ),
     jibImageBuild := SbtImageBuild.task(
       streams.value.log,
@@ -116,7 +119,8 @@ object JibPlugin extends AutoPlugin {
       jibJvmFlags.value,
       jibArgs.value,
       jibImageFormat.value,
-      jibEnvironment.value
+      jibEnvironment.value,
+      jibUseCurrentTimestamp.value
     ),
     jibTarImageBuild := {
       val args = spaceDelimited("<path>").parsed
@@ -131,7 +135,8 @@ object JibPlugin extends AutoPlugin {
           jibJvmFlags.value,
           jibArgs.value,
           jibImageFormat.value,
-          jibEnvironment.value
+          jibEnvironment.value,
+          jibUseCurrentTimestamp.value
         )
       }
 

--- a/src/main/scala/de/gccc/jib/SbtDockerBuild.scala
+++ b/src/main/scala/de/gccc/jib/SbtDockerBuild.scala
@@ -1,8 +1,7 @@
 package de.gccc.jib
 import java.nio.file.Files
-import java.time.Instant
 
-import com.google.cloud.tools.jib.api.{Containerizer, DockerDaemonImage, Jib}
+import com.google.cloud.tools.jib.api.{ Containerizer, DockerDaemonImage, Jib }
 import com.google.cloud.tools.jib.docker.DockerClient
 import com.google.cloud.tools.jib.image.ImageFormat
 import sbt.internal.util.ManagedLogger

--- a/src/main/scala/de/gccc/jib/SbtDockerBuild.scala
+++ b/src/main/scala/de/gccc/jib/SbtDockerBuild.scala
@@ -1,7 +1,8 @@
 package de.gccc.jib
 import java.nio.file.Files
+import java.time.Instant
 
-import com.google.cloud.tools.jib.api.{ Containerizer, DockerDaemonImage, Jib }
+import com.google.cloud.tools.jib.api.{Containerizer, DockerDaemonImage, Jib}
 import com.google.cloud.tools.jib.docker.DockerClient
 import com.google.cloud.tools.jib.image.ImageFormat
 import sbt.internal.util.ManagedLogger
@@ -21,7 +22,8 @@ private[jib] object SbtDockerBuild {
       defaultImage: String,
       jvmFlags: List[String],
       args: List[String],
-      environment: Map[String, String]
+      environment: Map[String, String],
+      useCurrentTimestamp: Boolean
   ): Unit = {
     if (!DockerClient.isDefaultDockerInstalled) {
       throw new Exception("Build to Docker daemon failed")
@@ -43,6 +45,7 @@ private[jib] object SbtDockerBuild {
         .setProgramArguments(args.asJava)
         .setFormat(ImageFormat.Docker)
         .setEntrypoint(configuration.entrypoint(jvmFlags))
+        .setCreationTime(TimestampHelper.useCurrentTimestamp(useCurrentTimestamp))
         .containerize(containerizer)
 
       logger.success("image successfully created & uploaded")

--- a/src/main/scala/de/gccc/jib/SbtImageBuild.scala
+++ b/src/main/scala/de/gccc/jib/SbtImageBuild.scala
@@ -1,8 +1,9 @@
 package de.gccc.jib
 
 import java.nio.file.Files
+import java.time.Instant
 
-import com.google.cloud.tools.jib.api.{ Containerizer, Jib }
+import com.google.cloud.tools.jib.api.{Containerizer, Jib}
 import com.google.cloud.tools.jib.image.ImageFormat
 import de.gccc.jib.JibPlugin.autoImport.JibImageFormat
 import sbt.internal.util.ManagedLogger
@@ -22,7 +23,8 @@ private[jib] object SbtImageBuild {
       jvmFlags: List[String],
       args: List[String],
       imageFormat: JibImageFormat,
-      environment: Map[String, String]
+      environment: Map[String, String],
+      useCurrentTimestamp: Boolean
   ): Unit = {
 
     val internalImageFormat = imageFormat match {
@@ -44,6 +46,7 @@ private[jib] object SbtImageBuild {
         .setProgramArguments(args.asJava)
         .setFormat(internalImageFormat)
         .setEntrypoint(configuration.entrypoint(jvmFlags))
+        .setCreationTime(TimestampHelper.useCurrentTimestamp(useCurrentTimestamp))
         .containerize(containerizer)
 
       logger.success("image successfully created & uploaded")

--- a/src/main/scala/de/gccc/jib/SbtImageBuild.scala
+++ b/src/main/scala/de/gccc/jib/SbtImageBuild.scala
@@ -1,9 +1,8 @@
 package de.gccc.jib
 
 import java.nio.file.Files
-import java.time.Instant
 
-import com.google.cloud.tools.jib.api.{Containerizer, Jib}
+import com.google.cloud.tools.jib.api.{ Containerizer, Jib }
 import com.google.cloud.tools.jib.image.ImageFormat
 import de.gccc.jib.JibPlugin.autoImport.JibImageFormat
 import sbt.internal.util.ManagedLogger

--- a/src/main/scala/de/gccc/jib/SbtTarImageBuild.scala
+++ b/src/main/scala/de/gccc/jib/SbtTarImageBuild.scala
@@ -1,9 +1,10 @@
 package de.gccc.jib
 
 import java.nio.file.Files
+import java.time.Instant
 
-import com.google.cloud.tools.jib.api.{ Containerizer, Jib, TarImage }
-import com.google.cloud.tools.jib.image.{ ImageFormat, ImageReference }
+import com.google.cloud.tools.jib.api.{Containerizer, Jib, TarImage}
+import com.google.cloud.tools.jib.image.{ImageFormat, ImageReference}
 import de.gccc.jib.JibPlugin.autoImport.JibImageFormat
 import sbt.internal.util.ManagedLogger
 
@@ -23,7 +24,8 @@ private[jib] object SbtTarImageBuild {
       jvmFlags: List[String],
       args: List[String],
       imageFormat: JibImageFormat,
-      environment: Map[String, String]
+      environment: Map[String, String],
+      useCurrentTimestamp: Boolean
   ): Unit = {
     val internalImageFormat = imageFormat match {
       case JibImageFormat.Docker => ImageFormat.Docker
@@ -50,6 +52,7 @@ private[jib] object SbtTarImageBuild {
         .setProgramArguments(args.asJava)
         .setFormat(internalImageFormat)
         .setEntrypoint(configuration.entrypoint(jvmFlags))
+        .setCreationTime(TimestampHelper.useCurrentTimestamp(useCurrentTimestamp))
         .containerize(containerizer)
 
       logger.success("image successfully created & uploaded")

--- a/src/main/scala/de/gccc/jib/SbtTarImageBuild.scala
+++ b/src/main/scala/de/gccc/jib/SbtTarImageBuild.scala
@@ -1,10 +1,9 @@
 package de.gccc.jib
 
 import java.nio.file.Files
-import java.time.Instant
 
-import com.google.cloud.tools.jib.api.{Containerizer, Jib, TarImage}
-import com.google.cloud.tools.jib.image.{ImageFormat, ImageReference}
+import com.google.cloud.tools.jib.api.{ Containerizer, Jib, TarImage }
+import com.google.cloud.tools.jib.image.{ ImageFormat, ImageReference }
 import de.gccc.jib.JibPlugin.autoImport.JibImageFormat
 import sbt.internal.util.ManagedLogger
 

--- a/src/main/scala/de/gccc/jib/TimestampHelper.scala
+++ b/src/main/scala/de/gccc/jib/TimestampHelper.scala
@@ -1,0 +1,10 @@
+package de.gccc.jib
+
+import java.time.Instant
+
+object TimestampHelper {
+
+  def useCurrentTimestamp(useCurrentTimestamp: Boolean) =
+    if (useCurrentTimestamp) Instant.now() else Instant.EPOCH
+
+}


### PR DESCRIPTION
Gradle and Maven plugins have a flag for using current timestamp for image creation time. See here https://github.com/GoogleContainerTools/jib/blob/master/docs/faq.md#why-is-my-image-created-48-years-ago. This PR enables the flag for sbt.