### PR TITLE
Custom repo location

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 
 This project tries to make a sbt plugin for the awesome [jib](https://github.com/GoogleContainerTools/jib) project from google.
 
+
+

--- a/README.md
+++ b/README.md
@@ -2,5 +2,31 @@
 
 This project tries to make a sbt plugin for the awesome [jib](https://github.com/GoogleContainerTools/jib) project from google.
 
+## settings
+    
+| name | type | description |
+| ---                            | --- | --- |
+| **jibBaseImage**                   | String | jib base image |
+| **jibBaseImageCredentialHelper**   | Option[String]] | jib base image credential helper |
+| **jibJvmFlags**                    | List[String]] | jib default jvm flags |
+| **jibArgs**                        | List[String]] | jib default args |
+| **jibEntrypoint**                  | Option[List[String]] | jib entrypoint |
+| **jibImageFormat**                 | JibImageFormat | jib default image format |
+| **jibTargetImageCredentialHelper** | Option[String] | jib base image credential helper |
+| **jibRegistry**                    | String | jib target image registry (defaults to docker hub) |
+| **jibOrganization**                | String | jib docker organization (defaults to organization) |
+| **jibName**                        | String | jib image name (defaults to project name) |
+| **jibVersion**                     | String | jib version (defaults to version) |
+| **jibEnvironment**                 | Map[String, String] | jib docker env variables |
+| **jibMappings**                    | Seq[(File, String)] | jib additional resource mappings |
+| **jibExtraMappings**               | Seq[(File, String)] | jib extra file mappings / i.e. java agents |
+| **jibUseCurrentTimestamp**         | Boolean | jib use current timestamp for image creation time. Default to Epoch |
+| **jibCustomRepositoryPath**        | Option[String] | jib custom repository path freeform path structure. <br>The default repo structure is organization/name |
 
+## commands
+| name               | description |
+| ---                | --- |
+| **jibDockerBuild**     | jib build docker image |
+| **jibImageBuild**      | jib build image (does not need docker) |
+| **jibTarImageBuild**   | jib build tar image |
 

--- a/src/main/scala/de/gccc/jib/JibPlugin.scala
+++ b/src/main/scala/de/gccc/jib/JibPlugin.scala
@@ -37,7 +37,9 @@ object JibPlugin extends AutoPlugin {
     val jibEnvironment                 = settingKey[Map[String, String]]("jib docker env variables")
     val jibMappings                    = taskKey[Seq[(File, String)]]("jib additional resource mappings")
     val jibExtraMappings               = taskKey[Seq[(File, String)]]("jib extra file mappings / i.e. java agents")
-    val jibUseCurrentTimestamp         = settingKey[Boolean]("jib use current timestamp for image creation time. Default to Epoch")
+    val jibUseCurrentTimestamp =
+      settingKey[Boolean]("jib use current timestamp for image creation time. Default to Epoch")
+    val jibCustomRepositoryPath = settingKey[Option[String]]("jib custom repository path freeform path structure")
 
     private[jib] object Private {
       val sbtLayerConfiguration = taskKey[List[LayerConfiguration]]("jib layer configuration")
@@ -66,6 +68,7 @@ object JibPlugin extends AutoPlugin {
     jibMappings := (mappings in Jib).value,
     jibExtraMappings := (mappings in JibExtra).value,
     jibUseCurrentTimestamp := false,
+    jibCustomRepositoryPath := None,
     // private values
     Private.sbtLayerConfiguration := {
       val stageDirectory     = target.value / "jib" / "stage"
@@ -99,7 +102,8 @@ object JibPlugin extends AutoPlugin {
         jibRegistry.value,
         jibOrganization.value,
         jibName.value,
-        jibVersion.value
+        jibVersion.value,
+        jibCustomRepositoryPath.value
       )
     },
     jibDockerBuild := SbtDockerBuild.task(

--- a/src/main/scala/de/gccc/jib/SbtTarImageBuild.scala
+++ b/src/main/scala/de/gccc/jib/SbtTarImageBuild.scala
@@ -32,9 +32,7 @@ private[jib] object SbtTarImageBuild {
     }
 
     try {
-      val imageReference = ImageReference.of(configuration.registry,
-                                         configuration.organization + "/" + configuration.name,
-                                         configuration.version)
+      val imageReference = ImageReference.of(configuration.registry, configuration.repository, configuration.version)
 
       val image = TarImage.at(home.toPath).named(imageReference)
 


### PR DESCRIPTION
This PR provides the ability to adjust the repository structure to your organisations needs.  By default the repository structure of organization/app_name covers most bases but there are exceptions.  Some teams work without a namespace at all or have unusual structures that do not fit.

These code changes keep the default behaviour but allow for freeform adjustment to the consumers desired wishes.

As an added bonus I've lifted the plugin code into the README to help reduce a developers need to go through the plugin code itself.