### PR TITLE
Snippet showing injection of a Java agent and some doc elaboration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,26 +7,61 @@ This project tries to make a sbt plugin for the awesome [jib](https://github.com
 | name | type | description |
 | ---                            | --- | --- |
 | **jibBaseImage**                   | String | jib base image |
-| **jibBaseImageCredentialHelper**   | Option[String]] | jib base image credential helper |
+| **jibBaseImageCredentialHelper**   | Option[String]] | jib base image credential helper cli name (e.g. ecr-login) |
 | **jibJvmFlags**                    | List[String]] | jib default jvm flags |
 | **jibArgs**                        | List[String]] | jib default args |
 | **jibEntrypoint**                  | Option[List[String]] | jib entrypoint |
 | **jibImageFormat**                 | JibImageFormat | jib default image format |
-| **jibTargetImageCredentialHelper** | Option[String] | jib base image credential helper |
+| **jibTargetImageCredentialHelper** | Option[String] | jib target image credential helper cli name |
 | **jibRegistry**                    | String | jib target image registry (defaults to docker hub) |
 | **jibOrganization**                | String | jib docker organization (defaults to organization) |
 | **jibName**                        | String | jib image name (defaults to project name) |
 | **jibVersion**                     | String | jib version (defaults to version) |
 | **jibEnvironment**                 | Map[String, String] | jib docker env variables |
-| **jibMappings**                    | Seq[(File, String)] | jib additional resource mappings |
-| **jibExtraMappings**               | Seq[(File, String)] | jib extra file mappings / i.e. java agents |
+| **jibMappings**                    | Seq[(File, String)] | jib additional resource mappings, <br>formatted as \<source file resource\> -> \<full path on container\> |
+| **jibExtraMappings**               | Seq[(File, String)] | jib extra file mappings / i.e. java agents <br>(see above for formatting) |
 | **jibUseCurrentTimestamp**         | Boolean | jib use current timestamp for image creation time. Default to Epoch |
 | **jibCustomRepositoryPath**        | Option[String] | jib custom repository path freeform path structure. <br>The default repo structure is organization/name |
 
 ## commands
+
 | name               | description |
 | ---                | --- |
 | **jibDockerBuild**     | jib build docker image |
 | **jibImageBuild**      | jib build image (does not need docker) |
 | **jibTarImageBuild**   | jib build tar image |
+
+## snippets and examples
+
+### injecting java agents
+
+This snippet shows how to inject a Java Agent (Kanela) into a container via jibExtraMappings.
+
+build.sbt
+```scala
+//...project stuff...
+javaAgents += "io.kamon" % "kanela-agent" % "1.0.5" % "dist;runtime;compile"
+//...project stuff...
+jibBaseImage := "openjdk:11-jre"
+jibName := "my-service"
+jibRegistry := "some-ecr-repository"
+jibUseCurrentTimestamp := true
+jibCustomRepositoryPath := Some(jibName.value)
+jibJvmFlags := List("-javaagent:/root/lib/kanela-agent.jar")
+jibExtraMappings := {
+    //javaAgents, Modules and ResolvedAgent come from the sbt-javaagent plugin
+    val resolved = javaAgents.value.map { agent =>
+        update.value.matching(Modules.exactFilter(agent.module)).headOption map {
+            jar => ResolvedAgent(agent, jar)
+        }
+    }
+    for {
+        resolvedAgent <- resolved.flatten
+    } yield {
+        resolvedAgent.artifact -> s"/root/lib/${resolvedAgent.agent.name}.jar"
+    }
+}
+jibTargetImageCredentialHelper := Some("ecr-login") 
+jibBaseImageCredentialHelper := Some("ecr-login")
+```
 

--- a/src/main/scala/de/gccc/jib/JibPlugin.scala
+++ b/src/main/scala/de/gccc/jib/JibPlugin.scala
@@ -22,8 +22,9 @@ object JibPlugin extends AutoPlugin {
       case object OCI    extends JibImageFormat
     }
 
-    val jibBaseImage                   = settingKey[String]("jib base image")
-    val jibBaseImageCredentialHelper   = settingKey[Option[String]]("jib base image credential helper")
+    val jibBaseImage = settingKey[String]("jib base image")
+    val jibBaseImageCredentialHelper =
+      settingKey[Option[String]]("jib base image credential helper cli name (e.g. ecr-login)")
     val jibJvmFlags                    = settingKey[List[String]]("jib default jvm flags")
     val jibArgs                        = settingKey[List[String]]("jib default args")
     val jibEntrypoint                  = settingKey[Option[List[String]]]("jib entrypoint")
@@ -31,14 +32,17 @@ object JibPlugin extends AutoPlugin {
     val jibDockerBuild                 = taskKey[ImageReference]("jib build docker image")
     val jibImageBuild                  = taskKey[ImageReference]("jib build image (does not need docker)")
     val jibTarImageBuild               = inputKey[Unit]("jib build tar image")
-    val jibTargetImageCredentialHelper = settingKey[Option[String]]("jib base image credential helper")
+    val jibTargetImageCredentialHelper = settingKey[Option[String]]("jib target image credential helper cli name")
     val jibRegistry                    = settingKey[String]("jib target image registry (defaults to docker hub)")
     val jibOrganization                = settingKey[String]("jib docker organization (defaults to organization)")
     val jibName                        = settingKey[String]("jib image name (defaults to project name)")
     val jibVersion                     = settingKey[String]("jib version (defaults to version)")
     val jibEnvironment                 = settingKey[Map[String, String]]("jib docker env variables")
-    val jibMappings                    = taskKey[Seq[(File, String)]]("jib additional resource mappings")
-    val jibExtraMappings               = taskKey[Seq[(File, String)]]("jib extra file mappings / i.e. java agents")
+    val jibMappings = taskKey[Seq[(File, String)]](
+      "jib additional resource mappings, formatted as <source file resource> -> <full path on container>"
+    )
+    val jibExtraMappings =
+      taskKey[Seq[(File, String)]]("jib extra file mappings / i.e. java agents (see above for formatting)")
     val jibUseCurrentTimestamp =
       settingKey[Boolean]("jib use current timestamp for image creation time. Default to Epoch")
     val jibCustomRepositoryPath = settingKey[Option[String]]("jib custom repository path freeform path structure")


### PR DESCRIPTION
This PR includes a correction in the documentation regarding the CredentialHelpers along with some elaboration on the purpose of the tuple found within mappings/extramappings.

Additionally there is a small snippet to help users with injecting artifacts into the container, for example, a Java Agent.