### PR TITLE
added additional credential retrievers (from config.json and google application)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val root = (project in file("."))
     name := "sbt-jib",
     // Add the default sonatype repository setting
     publishTo := sonatypePublishTo.value,
-    libraryDependencies += "com.google.cloud.tools" % "jib-core" % "0.16.0",
+    libraryDependencies += "com.google.cloud.tools" % "jib-core" % "0.17.0",
     releaseCrossBuild := true, // true if you cross-build the project for multiple Scala versions
     releaseProcess := Seq[ReleaseStep](
       checkSnapshotDependencies,

--- a/src/main/scala/de/gccc/jib/SbtConfiguration.scala
+++ b/src/main/scala/de/gccc/jib/SbtConfiguration.scala
@@ -117,6 +117,10 @@ private[jib] class SbtConfiguration(
 
     val factory = CredentialRetrieverFactory.forImage(imageReference, { case (logEvent: LogEvent) => { /* no-op */ } })
 
+    image.addCredentialRetriever(factory.dockerConfig())
+
+    image.addCredentialRetriever(factory.googleApplicationDefaultCredentials())
+
     image.addCredentialRetriever(factory.wellKnownCredentialHelpers())
 
     credHelper.foreach { helper =>

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.8.1-SNAPSHOT"
+version in ThisBuild := "0.8.2-SNAPSHOT"


### PR DESCRIPTION
It is impossible to load credentials in Google Cloud Build step at the moment using the scala-sbt community builder because you can't create an environment variable from a previous step and carry it to the "jib" step. Having the ability to load credentials from config.json should solve this head ache (the config.json content is regenerated for each build, so I can't simply reuse the same user/pass from it).