### PR TITLE
Check that the file is included in the resources

### DIFF
--- a/src/main/scala/de/gccc/jib/JibPlugin.scala
+++ b/src/main/scala/de/gccc/jib/JibPlugin.scala
@@ -93,6 +93,7 @@ object JibPlugin extends AutoPlugin {
         target.value,
         (Compile / products).value,
         (Compile / resourceDirectories).value,
+        (Compile / resources).value,
         (Compile / internalDependencyAsJars).value,
         (externalDependencyClasspath or (externalDependencyClasspath in Runtime)).value,
         jibExtraMappings.value,

--- a/src/main/scala/de/gccc/jib/SbtLayerConfigurations.scala
+++ b/src/main/scala/de/gccc/jib/SbtLayerConfigurations.scala
@@ -11,6 +11,7 @@ object SbtLayerConfigurations {
       targetDirectory: File,
       classes: Seq[File],
       resourceDirectories: Seq[File],
+      resources: Seq[File],
       internalDependencies: Keys.Classpath,
       external: Keys.Classpath,
       extraMappings: Seq[(File, String)],
@@ -27,7 +28,7 @@ object SbtLayerConfigurations {
     val resourcesLayer = {
       SbtJibHelper.mappingsConverter(
         "conf",
-        resourceDirectories.flatMap(MappingsHelper.contentOf(_, "/app/resources", _.isFile))
+        resourceDirectories.flatMap(MappingsHelper.contentOf(_, "/app/resources", f => f.isFile && resources.contains(f)))
       )
     }
 


### PR DESCRIPTION
This prevents files excluded e.g. by Compile / unmanagedResources / excludeFilter from showing up in the container