### PR TITLE
Set javac options release to 8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,12 @@ developers := List(
   )
 )
 
+inThisBuild(
+  Seq(
+    Compile / Keys.compile / javacOptions ++= Seq("--release", "8")
+  )
+)
+
 lazy val root = (project in file("."))
   .settings(
     name := "sbt-jib",

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,8 @@ developers := List(
 
 inThisBuild(
   Seq(
-    Compile / Keys.compile / javacOptions ++= Seq("--release", "8")
+    Compile / scalacOptions ++= Seq("-target:jvm-1.8"),
+    Compile / Keys.compile / javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
   )
 )
 


### PR DESCRIPTION
The 0.9.0 binary (https://search.maven.org/artifact/de.gccc.sbt/sbt-jib/0.9.0/jar) was compiled with Java 11 without source/target set to 1.8

When using this plugin with Java 1.8 I get the following error when running `jibImageBuild`

```
java.lang.UnsupportedClassVersionError: de/gccc/jib/JavaEntrypointConstructor has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
```

https://github.com/schmitch/sbt-jib/blob/master/.github/workflows/ci.yml#L16 seems to indicate this plugin supports 1.8.

This PR sets the Java source/target to 1.8