### PR TITLE
Additional image tags (fixes #66)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This project tries to make a sbt plugin for the awesome [jib](https://github.com
 | **jibVersion**                     | String | jib version (defaults to version) |
 | **jibEnvironment**                 | Map[String, String] | jib docker env variables |
 | **jibLabels**                      | Map[String, String] | jib docker labels |
+| **jibTags**                        | List[String] | jib image tags (in addition to jibVersion) |
 | **jibUser**                        | Option[String] | jib user and group to run the container as |
 | **jibMappings**                    | Seq[(File, String)] | jib additional resource mappings, <br>formatted as \<source file resource\> -> \<full path on container\> |
 | **jibExtraMappings**               | Seq[(File, String)] | jib extra file mappings / i.e. java agents <br>(see above for formatting) |

--- a/src/main/scala/de/gccc/jib/JibPlugin.scala
+++ b/src/main/scala/de/gccc/jib/JibPlugin.scala
@@ -38,6 +38,7 @@ object JibPlugin extends AutoPlugin {
     val jibVersion                     = settingKey[String]("jib version (defaults to version)")
     val jibEnvironment                 = settingKey[Map[String, String]]("jib docker env variables")
     val jibLabels                      = settingKey[Map[String, String]]("jib docker labels")
+    val jibTags                        = settingKey[List[String]]("jib image tags (in addition to jibVersion)")
     val jibTarget                      = settingKey[File]("""jib target folder (defaults to target.value / "jib")""")
     val jibAllowInsecureRegistries     = settingKey[Boolean]("""allow pushing to insecure registries""")
     val jibSendCredentialsOverHttp     = settingKey[Boolean]("""allow sending credentials over unencrypted HTTP""")
@@ -76,6 +77,7 @@ object JibPlugin extends AutoPlugin {
     jibVersion := version.value,
     jibEnvironment := Map.empty,
     jibLabels := Map.empty,
+    jibTags := List.empty,
     mappings in Jib := Nil,
     mappings in JibExtra := Nil,
     jibMappings := (mappings in Jib).value,
@@ -135,6 +137,7 @@ object JibPlugin extends AutoPlugin {
       jibEntrypoint.value,
       jibEnvironment.value,
       jibLabels.value,
+      jibTags.value,
       jibUser.value,
       jibUseCurrentTimestamp.value,
     ),
@@ -149,6 +152,7 @@ object JibPlugin extends AutoPlugin {
       jibImageFormat.value,
       jibEnvironment.value,
       jibLabels.value,
+      jibTags.value,
       jibUser.value,
       jibUseCurrentTimestamp.value,
     ),
@@ -167,6 +171,7 @@ object JibPlugin extends AutoPlugin {
           jibImageFormat.value,
           jibEnvironment.value,
           jibLabels.value,
+          jibTags.value,
           jibUser.value,
           jibUseCurrentTimestamp.value,
         )


### PR DESCRIPTION
Setting

```
jibTags := List("latest", "mycooltag")
```

Results in an image tagged with all of `jibVersion.value`, `latest`, and `mycooltag`.

My current target use case is to allow me to configure CD tooling to be aware of both SemVer releases and floating tags (and potentially other exotic uses as I imagine them 😆).