### PR TITLE
Support for platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,28 +4,29 @@ This project tries to make a sbt plugin for the awesome [jib](https://github.com
 
 ## settings
     
-| name | type | description |
-| ---                                | --- | --- |
-| **jibTarget**                      | Option[File] | jib work directory |
-| **jibBaseImage**                   | String | jib base image |
-| **jibBaseImageCredentialHelper**   | Option[String]] | jib base image credential helper cli name (e.g. ecr-login) |
-| **jibJvmFlags**                    | List[String]] | jib default jvm flags |
-| **jibArgs**                        | List[String]] | jib default args |
-| **jibEntrypoint**                  | Option[List[String]] | jib entrypoint |
-| **jibImageFormat**                 | JibImageFormat | jib default image format |
-| **jibTargetImageCredentialHelper** | Option[String] | jib target image credential helper cli name |
-| **jibRegistry**                    | String | jib target image registry (defaults to docker hub) |
-| **jibOrganization**                | String | jib docker organization (defaults to organization) |
-| **jibName**                        | String | jib image name (defaults to project name) |
-| **jibVersion**                     | String | jib version (defaults to version) |
-| **jibEnvironment**                 | Map[String, String] | jib docker env variables |
-| **jibLabels**                      | Map[String, String] | jib docker labels |
-| **jibTags**                        | List[String] | jib image tags (in addition to jibVersion) |
-| **jibUser**                        | Option[String] | jib user and group to run the container as |
-| **jibMappings**                    | Seq[(File, String)] | jib additional resource mappings, <br>formatted as \<source file resource\> -> \<full path on container\> |
-| **jibExtraMappings**               | Seq[(File, String)] | jib extra file mappings / i.e. java agents <br>(see above for formatting) |
-| **jibUseCurrentTimestamp**         | Boolean | jib use current timestamp for image creation time. Default to Epoch |
-| **jibCustomRepositoryPath**        | Option[String] | jib custom repository path freeform path structure. <br>The default repo structure is organization/name |
+| name                               | type                 | description                                                                                               |
+|------------------------------------|----------------------|-----------------------------------------------------------------------------------------------------------|
+| **jibTarget**                      | Option[File]         | jib work directory                                                                                        |
+| **jibBaseImage**                   | String               | jib base image                                                                                            |
+| **jibBaseImageCredentialHelper**   | Option[String]]      | jib base image credential helper cli name (e.g. ecr-login)                                                |
+| **jibJvmFlags**                    | List[String]]        | jib default jvm flags                                                                                     |
+| **jibArgs**                        | List[String]]        | jib default args                                                                                          |
+| **jibEntrypoint**                  | Option[List[String]] | jib entrypoint                                                                                            |
+| **jibImageFormat**                 | JibImageFormat       | jib default image format                                                                                  |
+| **jibTargetImageCredentialHelper** | Option[String]       | jib target image credential helper cli name                                                               |
+| **jibRegistry**                    | String               | jib target image registry (defaults to docker hub)                                                        |
+| **jibOrganization**                | String               | jib docker organization (defaults to organization)                                                        |
+| **jibName**                        | String               | jib image name (defaults to project name)                                                                 |
+| **jibVersion**                     | String               | jib version (defaults to version)                                                                         |
+| **jibEnvironment**                 | Map[String, String]  | jib docker env variables                                                                                  |
+| **jibPlatforms**                   | Set[Platform]        | jib platforms                                                                                             |
+| **jibLabels**                      | Map[String, String]  | jib docker labels                                                                                         |
+| **jibTags**                        | List[String]         | jib image tags (in addition to jibVersion)                                                                |
+| **jibUser**                        | Option[String]       | jib user and group to run the container as                                                                |
+| **jibMappings**                    | Seq[(File, String)]  | jib additional resource mappings, <br>formatted as \<source file resource\> -> \<full path on container\> |
+| **jibExtraMappings**               | Seq[(File, String)]  | jib extra file mappings / i.e. java agents <br>(see above for formatting)                                 |
+| **jibUseCurrentTimestamp**         | Boolean              | jib use current timestamp for image creation time. Default to Epoch                                       |
+| **jibCustomRepositoryPath**        | Option[String]       | jib custom repository path freeform path structure. <br>The default repo structure is organization/name   |
 
 ## commands
 

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ lazy val root = (project in file("."))
     name := "sbt-jib",
     // Add the default sonatype repository setting
     publishTo := sonatypePublishTo.value,
-    libraryDependencies += "com.google.cloud.tools" % "jib-core" % "0.19.0",
+    libraryDependencies += "com.google.cloud.tools" % "jib-core" % "0.20.0",
     releaseCrossBuild := true, // true if you cross-build the project for multiple Scala versions
     releaseProcess := Seq[ReleaseStep](
       checkSnapshotDependencies,

--- a/src/main/scala/de/gccc/jib/JibPlugin.scala
+++ b/src/main/scala/de/gccc/jib/JibPlugin.scala
@@ -2,7 +2,7 @@ package de.gccc.jib
 
 import java.nio.file.Files
 import com.google.cloud.tools.jib.api.ImageReference
-import com.google.cloud.tools.jib.api.buildplan.FileEntriesLayer
+import com.google.cloud.tools.jib.api.buildplan. { FileEntriesLayer, Platform }
 import sbt._
 import sbt.Keys._
 import complete.DefaultParsers._
@@ -37,6 +37,7 @@ object JibPlugin extends AutoPlugin {
     val jibName                        = settingKey[String]("jib image name (defaults to project name)")
     val jibVersion                     = settingKey[String]("jib version (defaults to version)")
     val jibEnvironment                 = settingKey[Map[String, String]]("jib docker env variables")
+    val jibPlatforms                   = settingKey[Set[Platform]]("jib platforms to build for")
     val jibLabels                      = settingKey[Map[String, String]]("jib docker labels")
     val jibTags                        = settingKey[List[String]]("jib image tags (in addition to jibVersion)")
     val jibTarget                      = settingKey[File]("""jib target folder (defaults to target.value / "jib")""")
@@ -76,6 +77,7 @@ object JibPlugin extends AutoPlugin {
     jibName := name.value,
     jibVersion := version.value,
     jibEnvironment := Map.empty,
+    jibPlatforms := Set(new Platform("amd64", "linux")),
     jibLabels := Map.empty,
     jibTags := List.empty,
     mappings in Jib := Nil,
@@ -140,6 +142,7 @@ object JibPlugin extends AutoPlugin {
       jibTags.value,
       jibUser.value,
       jibUseCurrentTimestamp.value,
+      jibPlatforms.value
     ),
     jibImageBuild := SbtImageBuild.task(
       streams.value.log,
@@ -155,6 +158,7 @@ object JibPlugin extends AutoPlugin {
       jibTags.value,
       jibUser.value,
       jibUseCurrentTimestamp.value,
+      jibPlatforms.value
     ),
     jibTarImageBuild := {
       val args = spaceDelimited("<path>").parsed

--- a/src/main/scala/de/gccc/jib/JibPlugin.scala
+++ b/src/main/scala/de/gccc/jib/JibPlugin.scala
@@ -15,6 +15,11 @@ object JibPlugin extends AutoPlugin {
     val Jib: Configuration      = config("jib")
     val JibExtra: Configuration = config("jib-extra-files")
 
+    object JibPlatforms {
+      val arm64 = new Platform("arm64", "linux")
+      val amd64 = new Platform("amd64", "linux")
+    }
+
     sealed trait JibImageFormat
     object JibImageFormat {
       case object Docker extends JibImageFormat
@@ -77,7 +82,7 @@ object JibPlugin extends AutoPlugin {
     jibName := name.value,
     jibVersion := version.value,
     jibEnvironment := Map.empty,
-    jibPlatforms := Set(new Platform("amd64", "linux")),
+    jibPlatforms := Set(JibPlatforms.amd64),
     jibLabels := Map.empty,
     jibTags := List.empty,
     mappings in Jib := Nil,

--- a/src/main/scala/de/gccc/jib/SbtDockerBuild.scala
+++ b/src/main/scala/de/gccc/jib/SbtDockerBuild.scala
@@ -1,6 +1,6 @@
 package de.gccc.jib
 import com.google.cloud.tools.jib.api.{ Containerizer, DockerDaemonImage, ImageReference, Jib }
-import com.google.cloud.tools.jib.api.buildplan.ImageFormat
+import com.google.cloud.tools.jib.api.buildplan.{ ImageFormat, Platform }
 import com.google.cloud.tools.jib.docker.DockerClient
 import sbt.internal.util.ManagedLogger
 
@@ -21,6 +21,7 @@ private[jib] object SbtDockerBuild {
       additionalTags: List[String],
       user: Option[String],
       useCurrentTimestamp: Boolean,
+      platforms: Set[Platform]
   ): ImageReference = {
     if (!DockerClient.isDefaultDockerInstalled) {
       throw new Exception("Build to Docker daemon failed")
@@ -36,6 +37,7 @@ private[jib] object SbtDockerBuild {
         .setFileEntriesLayers(configuration.getLayerConfigurations)
         .setUser(user.orNull)
         .setEnvironment(environment.asJava)
+        .setPlatforms(platforms.asJava)
         .setLabels(labels.asJava)
         .setProgramArguments(args.asJava)
         .setFormat(ImageFormat.Docker)

--- a/src/main/scala/de/gccc/jib/SbtImageBuild.scala
+++ b/src/main/scala/de/gccc/jib/SbtImageBuild.scala
@@ -1,7 +1,7 @@
 package de.gccc.jib
 
 import com.google.cloud.tools.jib.api.{ Containerizer, ImageReference, Jib }
-import com.google.cloud.tools.jib.api.buildplan.ImageFormat
+import com.google.cloud.tools.jib.api.buildplan.{ ImageFormat, Platform }
 import de.gccc.jib.JibPlugin.autoImport.JibImageFormat
 import sbt.internal.util.ManagedLogger
 
@@ -24,6 +24,7 @@ private[jib] object SbtImageBuild {
       additionalTags: List[String],
       user: Option[String],
       useCurrentTimestamp: Boolean,
+      platforms: Set[Platform]
   ): ImageReference = {
 
     val internalImageFormat = imageFormat match {
@@ -40,6 +41,7 @@ private[jib] object SbtImageBuild {
         .from(configuration.baseImageFactory(jibBaseImageCredentialHelper))
         .setFileEntriesLayers(configuration.getLayerConfigurations)
         .setEnvironment(environment.asJava)
+        .setPlatforms(platforms.asJava)
         .setLabels(labels.asJava)
         .setUser(user.orNull)
         .setProgramArguments(args.asJava)


### PR DESCRIPTION
Thanks for this plugin!

This adds platform support sbt-jib. Platform support means building for arm64, amd64 and such. 

Would be great if you could cut a release if this PR is approved and merged :)

Example usage in build.sbt:

```scala
jibPlatforms := Set(JibPlatforms.amd64, JibPlatforms.arm64)
```

Which results in 
<img width="1192" alt="Screenshot 2022-01-19 at 07 36 28" src="https://user-images.githubusercontent.com/141265/150077341-31466ac3-c4ac-44a7-885f-7776cac29970.png">

