### PR TITLE
Update jibBaseImage to use the official GraalVM image

### DIFF
--- a/src/main/scala/de/gccc/jib/JibPlugin.scala
+++ b/src/main/scala/de/gccc/jib/JibPlugin.scala
@@ -78,7 +78,7 @@ object JibPlugin extends AutoPlugin {
 
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
     // public values
-    jibBaseImage                   := "registry.hub.docker.com/schmitch/graalvm:latest",
+    jibBaseImage                   := "ghcr.io/graalvm/jdk:latest",
     jibBaseImageCredentialHelper   := None,
     jibTargetImageCredentialHelper := None,
     jibUser                        := None,


### PR DESCRIPTION
The old image hasn't been updated in over 4 years
https://hub.docker.com/r/schmitch/graalvm/tags
