### PR TITLE
ci: make release publishing work on `release` events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
     branches: [ master ]
   release:
     types: [ published ]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish as a stable release (e.g. v2.0.0)'
+        required: false
+        default: ''
 
 jobs:
   build:
@@ -45,6 +51,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          # For `release` events GITHUB_REF can be empty, so check out the tag
+          # explicitly. Falls back to a manually dispatched tag, then to the ref.
+          ref: ${{ github.event.release.tag_name || inputs.tag || github.ref }}
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
@@ -53,6 +62,11 @@ jobs:
       - uses: sbt/setup-sbt@v1
       - run: sbt ci-release
         env:
+          # sbt-ci-release decides "stable release vs snapshot" from the ref.
+          # On `release` events GITHUB_REF is empty, which made it skip the
+          # publish ("doing nothing"); CI_COMMIT_TAG is checked first and forces
+          # the stable-release path. Empty for branch pushes -> snapshot, as before.
+          CI_COMMIT_TAG: ${{ github.event.release.tag_name || inputs.tag }}
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}


### PR DESCRIPTION
## Problem

The v2.0.0 [publish run](https://github.com/sbt-jib/sbt-jib/actions/runs/28439958406/job/84275547195) was **green but published nothing**. The log shows:

```
Running ci-release.
  branch=
...
Snapshot releases must have -SNAPSHOT version number, doing nothing
```

`sbt-ci-release` decides "stable release vs snapshot" purely from the ref (`CI_COMMIT_TAG` / `GITHUB_REF`), not from git. On this `release` event `GITHUB_REF` came through **empty** (note the blank `branch=`, and the runner's *"event type release is not supported because it's not tied to a branch or tag ref"* warning), so `isTag` was `false`. Meanwhile sbt-dynver computed the clean tag version `2.0.0`, which is **not** a `-SNAPSHOT`, so it hit this branch in `CiReleasePlugin`:

```scala
if (!isTag) {
  if (isSnapshot) /* publish snapshot */
  else println("Snapshot releases must have -SNAPSHOT version number, doing nothing")
}
```

→ nothing published, exit 0. Confirmed: `2.0.0` is absent from Maven Central (latest is `1.4.x`).

## Fix

- **`CI_COMMIT_TAG: ${{ github.event.release.tag_name || inputs.tag }}`** — `sbt-ci-release` checks `CI_COMMIT_TAG` *before* the (empty) `GITHUB_REF`, forcing the stable-release path. Empty on branch pushes → snapshot, exactly as before.
- **`ref:` on checkout** — check out the tag explicitly so dynver computes the right version even when the ref is missing.
- **`workflow_dispatch`** (optional `tag` input) — lets us re-run a publish manually without cutting a new release.

## Notes

This keeps the existing release-driven flow. An alternative would be to switch to a tag-push trigger (`on: push: tags: ['v*']`), which also guarantees a non-empty `refs/tags/...` ref; happy to go that route instead if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)